### PR TITLE
:bug: fix: devtool in @premail/icons webpack config, make @premail/lo…

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -10,7 +10,3 @@ packageExtensions:
   "@storybook/addon-docs@*":
     dependencies:
       "@babel/core": "*"
-  chalk@5.0.1:
-    dependencies:
-      "#ansi-styles": npm:ansi-styles@6.1.0
-      "#supports-color": npm:supports-color@9.2.2

--- a/packages/premail-icons/package.json
+++ b/packages/premail-icons/package.json
@@ -34,7 +34,6 @@
     "@types/react-dom": "18.0.5",
     "@types/yargs": "^17.0.10",
     "babel-loader": "^8.2.5",
-    "chalk": "^5.0.1",
     "colors": "^1.4.0",
     "dotenv": "^16.0.1",
     "dotenv-cli": "^6.0.0",

--- a/packages/premail-icons/tsconfig.webpack.json
+++ b/packages/premail-icons/tsconfig.webpack.json
@@ -1,11 +1,12 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["types.d.ts", "src"],
+  "include": ["globals.d.ts", "src"],
   "exclude": [
     "scripts",
     "src/**/*.test.tsx",
     "src/**/*.test.ts",
     "src/**/*.storybook.tsx",
-    "src/**/*.stories.tsx"
+    "src/**/*.stories.tsx",
+    "src/__mocks__"
   ]
 }

--- a/packages/premail-icons/webpack.config.js
+++ b/packages/premail-icons/webpack.config.js
@@ -42,7 +42,6 @@ module.exports = {
     globalObject: "this",
   },
   // Devtool
-  devtool: "none",
   target: "web",
   mode: "production",
   optimization: {

--- a/packages/premail-logger/package.json
+++ b/packages/premail-logger/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@premail/logger",
   "packageManager": "yarn@3.2.1",
-  "type": "module",
   "devDependencies": {
     "rimraf": "^3.0.2",
     "typescript": "^4.7.4",
     "winston": "^3.8.1"
   },
   "dependencies": {
-    "chalk": "^5.0.1"
+    "colors": "^1.4.0"
   },
   "scripts": {
     "build": "rimraf build && tsc"

--- a/packages/premail-logger/src/index.ts
+++ b/packages/premail-logger/src/index.ts
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import colors from "colors";
 import winston from "winston";
 
 const options: winston.LoggerOptions = {
@@ -13,18 +13,18 @@ const options: winston.LoggerOptions = {
 
       switch (levelUpper) {
         case "INFO":
-          message = chalk.blue(message);
+          message = colors.blue(message);
           break;
 
         case "WARN":
-          message = chalk.yellow(message);
+          message = colors.yellow(message);
           break;
 
         case "ERROR":
-          message = chalk.red(message);
+          message = colors.red(message);
           break;
         case "DEBUG":
-          message = chalk.green(message);
+          message = colors.green(message);
           break;
 
         default:

--- a/packages/premail-logger/tsconfig.json
+++ b/packages/premail-logger/tsconfig.json
@@ -25,7 +25,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "NodeNext" /* Specify what module code is generated. */,
+    "module": "commonjs" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     "moduleResolution": "NodeNext" /* Specify how TypeScript looks up a file from a given module specifier. */,
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,20 +5,6 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"#ansi-styles@npm:ansi-styles@6.1.0":
-  version: 6.1.0
-  resolution: "ansi-styles@npm:6.1.0"
-  checksum: 7a7f8528c07a9d20c3a92bccd2b6bc3bb4d26e5cb775c02826921477377bd495d615d61f710d56216344b6238d1d11ef2b0348e146c5b128715578bfb3217229
-  languageName: node
-  linkType: hard
-
-"#supports-color@npm:supports-color@9.2.2":
-  version: 9.2.2
-  resolution: "supports-color@npm:9.2.2"
-  checksum: 976d84877402fc38c1d43b1fde20b0a8dc0283273f21cfebe4ff7507d27543cdfbeec7db108a96b82d694465f06d64e8577562b05d0520b41710088e0a33cc50
-  languageName: node
-  linkType: hard
-
 "@ampproject/remapping@npm:^2.1.0":
   version: 2.2.0
   resolution: "@ampproject/remapping@npm:2.2.0"
@@ -2455,7 +2441,6 @@ __metadata:
     "@types/react-dom": 18.0.5
     "@types/yargs": ^17.0.10
     babel-loader: ^8.2.5
-    chalk: ^5.0.1
     colors: ^1.4.0
     dotenv: ^16.0.1
     dotenv-cli: ^6.0.0
@@ -2488,7 +2473,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@premail/logger@workspace:packages/premail-logger"
   dependencies:
-    chalk: ^5.0.1
+    colors: ^1.4.0
     rimraf: ^3.0.2
     typescript: ^4.7.4
     winston: ^3.8.1
@@ -6729,13 +6714,6 @@ __metadata:
     ansi-styles: ^4.1.0
     supports-color: ^7.1.0
   checksum: fe75c9d5c76a7a98d45495b91b2172fa3b7a09e0cc9370e5c8feb1c567b85c4288e2b3fded7cfdd7359ac28d6b3844feb8b82b8686842e93d23c827c417e83fc
-  languageName: node
-  linkType: hard
-
-"chalk@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "chalk@npm:5.0.1"
-  checksum: 7b45300372b908f0471fbf7389ce2f5de8d85bb949026fd51a1b95b10d0ed32c7ed5aab36dd5e9d2bf3191867909b4404cef75c5f4d2d1daeeacd301dd280b76
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* Fix invalid devtool param in webpack.config
* remove chalk dependency and make premail logger cjs module
* regenerate yarn lock

This closes #54
This closes #55